### PR TITLE
improv: add booker system + trainline booker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,6 @@ COPY ./ /usr/src
 WORKDIR /usr/src
 ENV NODE_ENV production
 RUN yarn
-RUN "./node_modules/.bin/ts-node" "./utils/fetch_trainline_stations.ts"
+RUN "yarn" "generate"
 
 CMD ["./node_modules/.bin/ts-node", "./index.ts"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,5 +4,6 @@ COPY ./ /usr/src
 WORKDIR /usr/src
 ENV NODE_ENV production
 RUN yarn
+RUN "./node_modules/.bin/ts-node" "./utils/fetch_trainline_stations.ts"
 
 CMD ["./node_modules/.bin/ts-node", "./index.ts"]

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -5,21 +5,23 @@ import * as bodyParser from 'body-parser'
 import * as cors from 'cors'
 import TravelController from './src/controllers/travel.controller'
 import NotifierController from './src/controllers/notifier.controller'
+import BookerController from './src/controllers/booker.controller'
 import fetch from 'node-fetch'
 
 const db = new Database()
 const app = express()
 db.connect().then(async () => {
   await TravelEntity.deleteOld()
-  const travels = await TravelEntity.find({ relations: ['notifier'] })
-  travels.forEach(travel => travel.initCrawler())
-  console.log(`${travels.length} crawlers initiated.`)
+  const travels = await TravelEntity.find({ relations: ['notifier', 'booker'] })
+  travels.forEach(travel => travel.init())
+  console.log(`${travels.length} travels initiated.`)
 
   app.use(cors())
   app.use(bodyParser.json())
   const router = express.Router()
   router.use('/travels', TravelController.router)
   router.use('/notifiers', NotifierController.router)
+  router.use('/bookers', BookerController.router)
   router.use('/stations/autocomplete', async (req: express.Request, res: express.Response) => {
     if (req.query.searchTerm.length < 2) {
       return res.send([])

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,8 @@
 {
+  "scripts": {
+    "generate": "ts-node ./utils/fetch_trainline_stations.json"
+  },
   "dependencies": {
-    "@types/express": "^4.17.0",
-    "@types/node": "^12.6.8",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "debug": "^4.1.1",
@@ -14,5 +15,10 @@
     "typeorm": "^0.2.18",
     "typescript": "^3.5.3",
     "vue": "^2.6.10"
+  },
+  "devDependencies": {
+    "@types/body-parser": "^1.19.1",
+    "@types/node": "^16.9.1",
+    "csv-parse": "^4.16.3"
   }
 }

--- a/backend/src/book/interface.ts
+++ b/backend/src/book/interface.ts
@@ -1,5 +1,5 @@
-import TravelEntity from 'src/entities/travel.entity'
-import { NotifierInterface } from 'src/notify/interface'
+import TravelEntity from '../entities/travel.entity'
+import { NotifierInterface } from '../notify/interface'
 import TrainlineBooker from './trainline'
 import OuiSNCFBooker from './ouisncf'
 

--- a/backend/src/book/interface.ts
+++ b/backend/src/book/interface.ts
@@ -1,0 +1,29 @@
+import TravelEntity from 'src/entities/travel.entity'
+import { NotifierInterface } from 'src/notify/interface'
+import TrainlineBooker from './trainline'
+import OuiSNCFBooker from './ouisncf'
+
+export type Credentials = {
+  username: string
+  password: string
+}
+
+export interface BookerInterface {
+  destroy(): Promise<void>
+}
+
+export enum BookerType {
+  trainline = 'trainline',
+  ouisncf = 'ouisncf',
+}
+
+export const createBooker = (type: BookerType, travel: TravelEntity, notifier: NotifierInterface, credentials: Credentials): BookerInterface => {
+  switch(type) {
+    case BookerType.trainline:
+      return new TrainlineBooker(travel, notifier, credentials)
+    case BookerType.ouisncf:
+      return new OuiSNCFBooker(travel, notifier)
+    default:
+      throw new Error(`Invalid booker type: ${type}`)
+  }
+}

--- a/backend/src/book/trainline.ts
+++ b/backend/src/book/trainline.ts
@@ -1,0 +1,541 @@
+import { BookerInterface, Credentials } from './interface'
+import * as fetch from 'node-fetch'
+import TravelEntity from '../entities/travel.entity'
+import { NotifierInterface } from '../notify/interface'
+import { getHourFromDate, getHumanDate } from '../utils/date'
+import * as debug from 'debug'
+
+const trainlineStations = require('../../trainline_stations.json')
+
+const endpoint = 'https://www.trainline.fr/api/v5_1'
+const headers = {
+  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36',
+  'x-user-agent': 'CaptainTrain/1629887560(web) (Ember 3.9.1)',
+  'x-not-a-bot': 'i-am-human',
+  'origin': 'chrome-extension://fhbjgbiflinjbdggehcddcbncdddomop',
+  'accept' : '*/*',
+}
+
+type LoginRequest = {
+  id: number
+  email: string
+  password: string
+}
+type LoginResponse = {
+  user: {
+    id: string
+    first_name: string
+    last_name: string
+    oldest_departure_date: string // ISO string
+    suggested_travels: any[]
+    passenger_ids: string[]
+    suggested_station_ids: string[] // trainline ids
+  }
+  meta: {
+    token: string
+  }
+  passengers: {
+    id: string
+    first_name: string
+    last_name: string
+    card_ids: any[]
+  }[]
+  cards: {
+    id: string // trainline id
+    created_at: string // iso date
+    number: string // sncf number
+    reference: 'SNCF.HappyCard' | 'SNCF.CarteVoyageur' | string
+  }[]
+  errors?: {
+    email?: string[]
+  }
+}
+type SearchTrainRequest = {
+  search: {
+    arrival_station_id: string
+    card_ids: string[],
+    cuis: {},
+    departure_date: string, // ISO date
+    departure_station_id: string
+    exchangeable_part: null,
+    exchangeable_pnr_id: null,
+    is_next_available: false,
+    is_previous_available: false,
+    passenger_ids: string[],
+    return_date: null,
+    source: null,
+    systems: ('sncf' | string)[]
+    via_station_id: null
+  }
+}
+type SearchTrainResponse = {
+  folders?: {
+    id: string
+    trip_ids: string[]
+    search_id: string
+    departure_date: string
+    departure_station_id: string // long trainline id
+    arrival_date: string
+    arrival_station_id: string // long trainline id
+    cents: number // should be 0 if the train is free
+    system: 'sncf' | 'flixbus' | 'busbud' | 'pao_sncf' | 'pao_ouigo' | string
+  }[]
+  trips?: {
+    id: string
+    segment_ids: string[]
+    folder_id: string
+    departure_date: string
+    departure_station_id: string // short trainline id (e.g. 4718)
+    arrival_date: string
+    arrival_station_id: string // short trainline id (e.g. 4718)
+    cents: number // should be 0 if the train is free
+    short_unsellable_reason?: string
+    long_unsellable_reason?: "Il n’y a plus de places TGVmax disponibles sur ce trajet." | string
+  }[]
+  segments?: {
+    id: string
+    trip_id: string
+    train?: 'tgv_inoui' | string
+    train_name?: 'TGV INOUI' | string
+    train_number?: string
+    departure_date: string
+    departure_station_id: string // short trainline id (e.g. 4718)
+    arrival_date: string
+    arrival_station_id: string // short trainline id (e.g. 4718)
+    carrier: 'sncf' | string
+    brand: 'tgvmax' | string
+    co2_emission?: number
+  }[]
+  stations?: {
+    id: string // short or long
+    name: string // long name (e.g. Lyon (Perrache))
+    slug: string // e.g. lyon
+  }[]
+  search?: {
+    id: string
+    is_next_available?: boolean
+    is_previous_available?: boolean
+  }
+  error?: string
+}
+type BookRequest = {
+  book: {
+    options: Record<string, { // key is segment id
+      comfort_class: "pao.default"
+      seat: 'no_preference' | 'aisle' | 'twin' | 'lower_deck'
+    }>,
+    outward_folder_id: string
+    search_id: string
+  }
+}
+type BookResponse = {
+  pnrs?: { // there is generally only 1 PNR if it's one-way ticket
+    id: string
+    system: 'pao_sncf' | string
+  }[]
+  folders?: {
+    id: string
+    pnr_id: string
+    trip_ids: string[]
+  }[]
+  book?: {
+    id: string
+    pnr_ids: string[]
+  }
+}
+type PaymentRequest = {
+  payment: {
+    can_save_payment_card: false,
+    card_form_session: null,
+    cents: 0,
+    currency: 'EUR',
+    cvv_code: null,
+    device_data: null,
+    digitink_value: null,
+    expiration_month: null,
+    expiration_year: null,
+    holder: null,
+    is_new_customer: false,
+    mean: 'free',
+    nonce: null,
+    number: null,
+    order_id: null,
+    payment_card_id: null,
+    paypal_country: null,
+    paypal_email: null,
+    paypal_first_name: null,
+    paypal_last_name: null,
+    pnr_ids: string[], // this is the only one that matters here
+    pro_save_card: false,
+    ravelin_device_id: null,
+    status: null,
+    verification_form: null,
+    verification_url: null,
+    wants_all_marketing: null
+  }
+}
+type PaymentResponse = {
+  payment?: {
+    id: string
+    status: 'waiting_for_confirmation' | string
+  }
+}
+type ConfirmRequest = {
+	payment: {
+		after_sales_charge_ids: [],
+		can_save_payment_card: false,
+		card_form_session: null,
+		cents: 0,
+		coupon_ids: [],
+		currency: 'EUR',
+		cvv_code: null,
+		device_data: null,
+		digitink_value: null,
+		exchange_ids: [],
+		expiration_month: null,
+		expiration_year: null,
+		holder: null,
+		is_new_customer: false,
+		mean: 'free',
+		nonce: null,
+		number: null,
+		order_id: null,
+		payment_card_id: null,
+		paypal_country: null,
+		paypal_email: null,
+		paypal_first_name: null,
+		paypal_last_name: null,
+		pnr_ids: string[], // this is the only one that matters here
+		pro_save_card: false,
+		ravelin_device_id: null,
+		status: 'waiting_for_confirmation',
+		subscription_ids: [],
+		verification_form: null,
+		verification_url: null,
+		wants_all_marketing: null
+	}
+}
+type ConfirmResponse = {
+  segments?: {
+    id: string
+    car?: string
+    seat?: string
+    train_number?: string
+  }[]
+}
+
+export default class TrainlineBooker implements BookerInterface {
+  private credentials: Credentials
+  private token?: LoginResponse
+  private interval: NodeJS.Timeout
+  private travel: TravelEntity
+  private notifier: NotifierInterface
+  private logger: debug
+
+  private departureId: string
+  private arrivalId: string
+
+  constructor(travel: TravelEntity, notifier: NotifierInterface, credentials: Credentials) {
+    this.travel = travel
+    this.notifier = notifier
+    this.credentials = credentials
+    this.logger = debug(`booker:trainline:${this.travel.from}-${this.travel.to}_${this.date}`)
+    this.logger(`Init booker`)
+
+    this.departureId = trainlineStations[this.travel.from]
+    if (!this.departureId) {
+      this.logger(`Cannot get trainline id for station "${this.travel.from}"`)
+      return
+    }
+    this.arrivalId = trainlineStations[this.travel.to]
+    if (!this.arrivalId) {
+      this.logger(`Cannot get trainline id for station "${this.travel.from}"`)
+      return
+    }
+
+    this.interval = setInterval(this.check.bind(this), 1000 * 60 * 30)
+    this.interval.unref()
+
+    this.check()
+  }
+
+  async destroy () {
+    clearInterval(this.interval)
+  }
+
+  private get date () {
+    return this.travel.date.toISOString().split('T')[0]
+  }
+
+  private async check() {
+    if (!(await this.checkToken())) {
+      await this.login()
+    }
+    const date = this.travel.date
+    date.setHours(this.travel.minHour)
+
+    const trips = await this.search({
+      departure: date,
+      departureStationId: this.departureId,
+      arrivalStationId: this.arrivalId,
+    })
+    const bookableTrips = trips.trips
+      .filter(trip => trip.cents === 0 && trip.long_unsellable_reason === undefined) // filter only tgv max trips
+      .filter((trip) => {
+        // filter hours (sometimes trainline returns trains that doesn't respect the request)
+        const date = new Date(trip.departure_date)
+        if (this.travel.minHour && date.getHours() < this.travel.minHour) {
+          return false
+        }
+        if (this.travel.maxHour && date.getHours() > this.travel.maxHour) {
+          return false
+        }
+        return true
+      })
+      .sort((a, b) => a.departure_date.localeCompare(b.departure_date))
+    if (bookableTrips.length === 0) {
+      this.logger('No bookable trip')
+      return
+    }
+    this.logger(`Found ${bookableTrips.length} trips`)
+
+    const trip = bookableTrips[0]
+
+    await this.notifier.send(this.formatMessageAvailable(bookableTrips))
+
+    this.logger(`Book trip ${trip.id}`)
+    const book = await this.book({ segmentIds: trip.segment_ids, folderId: trip.folder_id, searchId: trips.search.id })
+
+    this.logger(`Pay pnr ${book.book.pnr_ids.join(',')}`)
+    const payment = await this.payment({ pnrIds: book.book.pnr_ids })
+
+    this.logger(`Confirm payment ${payment.payment.id}`)
+    const confirm = await this.confirm({ paymentId: payment.payment.id, pnrIds: book.book.pnr_ids })
+
+    this.logger(`Trip booked! Delete travel`)
+    TravelEntity.deleteById(this.travel.id)
+
+    return this.notifier.send(this.formatMessageBooked(trip, confirm))
+  }
+
+  private async search(input: {
+    departure: Date
+    departureStationId: string,
+    arrivalStationId: string
+  }): Promise<SearchTrainResponse> {
+    const res = await fetch(endpoint + '/search', {
+      method: 'POST',
+      headers: {
+        ...headers,
+        'authorization': `Token token="${this.token.meta.token}"`,
+        accept: 'application/json, text/javascript, */*; q=0.01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        search: {
+          arrival_station_id: input.arrivalStationId,
+          card_ids: this.token.passengers[0].card_ids,
+          cuis: {},
+          departure_date: input.departure.toISOString(),
+          departure_station_id: input.departureStationId,
+          exchangeable_part: null,
+          exchangeable_pnr_id: null,
+          is_next_available: false,
+          is_previous_available: false,
+          passenger_ids: [ this.token.passengers[0].id ],
+          return_date: null,
+          source: null,
+          systems: [
+            'sncf',
+          ],
+          via_station_id: null
+        }
+      } as SearchTrainRequest),
+    })
+
+    const trips: SearchTrainResponse = await res.json()
+    return trips
+  }
+
+  private async book(input: {
+    segmentIds: string[]
+    folderId: string
+    searchId: string
+  }): Promise<BookResponse> {
+    const options: Record<string, any> = {}
+    for (const sid of input.segmentIds) {
+      options[sid] = {
+        comfort_class: 'pao.default',
+        seat: 'no_preference', // TODO: set a preference when creating the booker
+      }
+    }
+    const res = await fetch(endpoint + '/book', {
+      method: 'POST',
+      headers: {
+        ...headers,
+        'authorization': `Token token="${this.token.meta.token}"`,
+        accept: 'application/json, text/javascript, */*; q=0.01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        book: {
+          options: options,
+          outward_folder_id: input.folderId,
+          search_id: input.searchId,
+        }
+      } as BookRequest),
+    })
+    const book: BookResponse = await res.json()
+    return book
+  }
+
+  private async payment(input: { pnrIds: string[] }) {
+    const res = await fetch(endpoint + '/payments', {
+      method: 'POST',
+      headers: {
+        ...headers,
+        'authorization': `Token token="${this.token.meta.token}"`,
+        accept: 'application/json, text/javascript, */*; q=0.01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        payment: {
+          can_save_payment_card: false,
+          card_form_session: null,
+          cents: 0,
+          currency: 'EUR',
+          cvv_code: null,
+          device_data: null,
+          digitink_value: null,
+          expiration_month: null,
+          expiration_year: null,
+          holder: null,
+          is_new_customer: false,
+          mean: 'free',
+          nonce: null,
+          number: null,
+          order_id: null,
+          payment_card_id: null,
+          paypal_country: null,
+          paypal_email: null,
+          paypal_first_name: null,
+          paypal_last_name: null,
+          pnr_ids: input.pnrIds,
+          pro_save_card: false,
+          ravelin_device_id: null,
+          status: null,
+          verification_form: null,
+          verification_url: null,
+          wants_all_marketing: null
+        }
+      } as PaymentRequest),
+    })
+    const payment: PaymentResponse = await res.json()
+    return payment
+  }
+
+  private async confirm(input: { paymentId: string, pnrIds: string[] }) {
+    const res = await fetch(endpoint + '/payments/' + input.paymentId + '/confirm', {
+      method: 'POST',
+      headers: {
+        ...headers,
+        'authorization': `Token token="${this.token.meta.token}"`,
+        accept: 'application/json, text/javascript, */*; q=0.01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        payment: {
+          after_sales_charge_ids: [],
+          can_save_payment_card: false,
+          card_form_session: null,
+          cents: 0,
+          coupon_ids: [],
+          currency: 'EUR',
+          cvv_code: null,
+          device_data: null,
+          digitink_value: null,
+          exchange_ids: [],
+          expiration_month: null,
+          expiration_year: null,
+          holder: null,
+          is_new_customer: false,
+          mean: 'free',
+          nonce: null,
+          number: null,
+          order_id: null,
+          payment_card_id: null,
+          paypal_country: null,
+          paypal_email: null,
+          paypal_first_name: null,
+          paypal_last_name: null,
+          pnr_ids: input.pnrIds,
+          pro_save_card: false,
+          ravelin_device_id: null,
+          status: 'waiting_for_confirmation',
+          subscription_ids: [],
+          verification_form: null,
+          verification_url: null,
+          wants_all_marketing: null
+        }
+      } as ConfirmRequest)
+    })
+    const confirm: ConfirmResponse = await res.json()
+    return confirm
+  }
+
+  private async login() {
+    this.logger('login')
+    const res = await fetch(endpoint + '/account/signin', {
+      method: 'POST',
+      headers: {
+        ...headers,
+        accept: 'application/json, text/javascript, */*; q=0.01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: 1,
+        email: this.credentials.username,
+        password: this.credentials.password,
+      } as LoginRequest)
+    })
+    let token: LoginResponse = await res.json()
+    this.token = token
+
+    if (this.token.passengers.length > 1) {
+      this.notifier.send(`Il y a ${this.token.passengers.length} passagers sur ce compte Trainline, seulement le premier (${this.token.passengers[0].first_name}) sera utilise pour la reservation.`)
+    }
+  }
+
+  private async checkToken(): Promise<boolean> {
+    if (!this.token) {
+      return false
+    }
+
+    const res = await fetch(endpoint + '/user', {
+      headers: {
+        ...headers,
+        'authorization': `Token token="${this.token.meta.token}"`,
+      }
+    })
+    return res.ok
+  }
+
+  private formatMessageAvailable (trips: SearchTrainResponse['trips']): string {
+    let content = `Des billets TGVMax sont disponible pour le ${this.date}:`
+    trips.forEach((trip) => {
+      content += `\n- ${this.travel.from}-${this.travel.to}: ${getHourFromDate(new Date(trip.departure_date))}-${getHourFromDate(new Date(trip.arrival_date))}`
+    })
+    if (this.travel.book) {
+      content += `\n\n Une reservation va etre tentee pour le premier train.`
+    }
+    return content
+  }
+
+  private formatMessageBooked(trip: SearchTrainResponse['trips'][0], confirm: ConfirmResponse): string {
+    let content = `Un billet a ete reserve pour le ${getHumanDate(new Date(trip.departure_date))} et une arrivee le ${getHumanDate(new Date(trip.arrival_date))}:`
+    for (const segment of confirm.segments) {
+      content += `\n- train #${segment.train_number || 'inconnu'} (voiture ${segment.car || 'inconnue'} siege ${segment.seat || 'inconnu'})`
+    }
+    return content
+  }
+}

--- a/backend/src/controllers/booker.controller.ts
+++ b/backend/src/controllers/booker.controller.ts
@@ -1,0 +1,32 @@
+import BookerEntity from '../entities/booker.entity'
+import TravelEntity from '../entities/travel.entity'
+import * as express from 'express'
+
+export default class BookerController {
+
+  static get router () {
+    const routerBookers = express.Router()
+    routerBookers.get('/', this.list)
+    routerBookers.post('/', this.create)
+    routerBookers.delete('/:id', this.delete)
+    return routerBookers
+  }
+
+  static async list (req: express.Request, res: express.Response) {
+    const bookers = await BookerEntity.find()
+    return res.send(bookers)
+  }
+
+  static async create (req: express.Request, res: express.Response) {
+    const booker = await BookerEntity.insert(req.body)
+    return res.send({ ...booker.generatedMaps[0], ...req.body })
+  }
+
+  static async delete (req: express.Request, res: express.Response) {
+    const travelsWithThisBooker = await TravelEntity.find({ booker: req.params.id })
+    if (travelsWithThisBooker.length > 0) return res.status(400).send({ msg: `You can't delete a booker attached.` })
+    const booker = await BookerEntity.delete({ id: req.params.id })
+    return res.send(booker)
+  }
+
+}

--- a/backend/src/controllers/travel.controller.ts
+++ b/backend/src/controllers/travel.controller.ts
@@ -12,12 +12,13 @@ export default class TravelController {
   }
 
   static async list (req: express.Request, res: express.Response) {
-    const travels = await TravelEntity.find({ relations: ['notifier'] })
+    const travels = await TravelEntity.find({ relations: ['notifier', 'booker'] })
     return res.send(travels)
   }
 
   static async create (req: express.Request, res: express.Response) {
     if (!req.body.notifier) return res.status(400).send({ msg: 'You need to provide a notifier.' })
+    if (!req.body.booker) return res.status(400).send({ msg: 'You need to provide a booker.' })
     const travel = await TravelEntity.insertAndCrawl(req.body)
     return res.send(travel)
   }

--- a/backend/src/entities/booker.entity.ts
+++ b/backend/src/entities/booker.entity.ts
@@ -1,0 +1,41 @@
+import { NotifierInterface } from "src/notify/interface"
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, CreateDateColumn, OneToMany } from "typeorm"
+import { BookerInterface, BookerType, createBooker } from "../book/interface"
+import TravelEntity from './travel.entity'
+
+@Entity({name: "bookers"})
+export default class BookerEntity extends BaseEntity {
+
+  @PrimaryGeneratedColumn()
+  id: number
+
+  @Column()
+  name: string
+
+  @Column()
+  username?: string
+
+  @Column()
+  password?: string
+
+  @Column()
+  type: BookerType
+
+  @OneToMany(type => TravelEntity, travel => travel.booker)
+  travels: TravelEntity[]
+
+  @CreateDateColumn()
+  created_at: Date
+
+  toJSON() {
+    return Object.assign({}, this, { password: undefined })
+  }
+
+  init (travel: TravelEntity, notifier: NotifierInterface): BookerInterface {
+    const booker = createBooker(this.type, travel, notifier, {
+      username: this.username,
+      password: this.password
+    })
+    return booker
+  } 
+}

--- a/backend/src/entities/notifier.entity.ts
+++ b/backend/src/entities/notifier.entity.ts
@@ -1,5 +1,5 @@
-import { NotifierInterface } from "src/notify/interface"
-import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, CreateDateColumn, OneToMany } from "typeorm"
+import { NotifierInterface } from '../notify/interface'
+import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, CreateDateColumn, OneToMany } from 'typeorm'
 import SmsNotifier from '../notify/sms'
 import TravelEntity from './travel.entity'
 

--- a/backend/src/entities/notifier.entity.ts
+++ b/backend/src/entities/notifier.entity.ts
@@ -1,3 +1,4 @@
+import { NotifierInterface } from "src/notify/interface"
 import { Entity, PrimaryGeneratedColumn, Column, BaseEntity, CreateDateColumn, OneToMany } from "typeorm"
 import SmsNotifier from '../notify/sms'
 import TravelEntity from './travel.entity'
@@ -34,7 +35,7 @@ export default class NotifierEntity extends BaseEntity {
     return Object.assign({}, this, { username: undefined, password: undefined })
   }
 
-  init (): SmsNotifier {
+  init (): NotifierInterface {
     let notifier
     switch (this.type) {
       case Type.sms:

--- a/backend/src/utils/date.ts
+++ b/backend/src/utils/date.ts
@@ -1,0 +1,8 @@
+export const getHourFromDate = (date: Date) => {
+  return date.getHours().toString().padStart(2, '0') + 'h' +
+    date.getMinutes().toString().padStart(2, '0')
+}
+
+export const getHumanDate = (date: Date) => {
+  return date.toISOString().split('T')[0] + ' a ' + getHourFromDate(date)
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "outDir": "build/src",
     "rootDirs": ["."],
     "moduleResolution": "node",

--- a/backend/utils/fetch_trainline_stations.ts
+++ b/backend/utils/fetch_trainline_stations.ts
@@ -1,0 +1,18 @@
+import * as fetch from 'node-fetch'
+const parse = require('csv-parse/lib/sync')
+import { writeFileSync } from 'fs'
+
+const main = async () => {
+  const res = await fetch('https://raw.githubusercontent.com/trainline-eu/stations/master/stations.csv', {})
+  const stations: Record<string, string> = {}
+  const lines = parse(await res.text(), {
+    columns: true,
+    delimiter: ';'
+  })
+  for (const line of lines.filter(line => line.sncf_is_enabled === 't' && line.sncf_id !== '')) {
+    stations[line.sncf_id] = line.id
+  }
+  writeFileSync('./trainline_stations.json', JSON.stringify(stations))
+}
+
+main()

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@types/body-parser@*":
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
-  integrity sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==
+"@types/body-parser@^1.19.1":
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.1.tgz#0c0174c42a7d017b818303d4b5d969cb0b75929c"
+  integrity sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"
@@ -17,45 +17,15 @@
   dependencies:
     "@types/node" "*"
 
-"@types/express-serve-static-core@*":
-  version "4.16.7"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz#50ba6f8a691c08a3dd9fa7fba25ef3133d298049"
-  integrity sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==
-  dependencies:
-    "@types/node" "*"
-    "@types/range-parser" "*"
-
-"@types/express@^4.17.0":
-  version "4.17.0"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.0.tgz#49eaedb209582a86f12ed9b725160f12d04ef287"
-  integrity sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "*"
-    "@types/serve-static" "*"
-
-"@types/mime@*":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
-  integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
-
-"@types/node@*", "@types/node@^12.6.8":
+"@types/node@*":
   version "12.6.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
   integrity sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==
 
-"@types/range-parser@*":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
-  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
-
-"@types/serve-static@*":
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"
-  integrity sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==
-  dependencies:
-    "@types/express-serve-static-core" "*"
-    "@types/mime" "*"
+"@types/node@^16.9.1":
+  version "16.9.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.1.tgz#0611b37db4246c937feef529ddcc018cf8e35708"
+  integrity sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==
 
 abbrev@1:
   version "1.1.1"
@@ -356,6 +326,11 @@ cors@^2.8.5:
   dependencies:
     object-assign "^4"
     vary "^1"
+
+csv-parse@^4.16.3:
+  version "4.16.3"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.16.3.tgz#7ca624d517212ebc520a36873c3478fa66efbaf7"
+  integrity sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -844,12 +819,24 @@ mime-db@1.40.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
-mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-db@1.49.0:
+  version "1.49.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.49.0.tgz#f3dfde60c99e9cf3bc9701d687778f537001cbed"
+  integrity sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==
+
+mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.24"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
   integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
   dependencies:
     mime-db "1.40.0"
+
+mime-types@~2.1.24:
+  version "2.1.32"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.32.tgz#1d00e89e7de7fe02008db61001d9e02852670fd5"
+  integrity sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==
+  dependencies:
+    mime-db "1.49.0"
 
 mime@1.6.0:
   version "1.6.0"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,10 +3,12 @@
     <div class="flex flex-wrap mb-4">
       <div class="w-full md:w-1/2 p-10">
         <AddTravel/>
+        <AddBooker/>
         <AddNotifier/>
       </div>
       <div class="w-full md:w-1/2 p-10">
         <ListTravels/>
+        <ListBookers/>
         <ListNotifiers/>
       </div>
     </div>
@@ -15,16 +17,20 @@
 
 <script>
 import AddTravel from './components/AddTravel'
+import AddBooker from './components/AddBooker'
 import AddNotifier from './components/AddNotifier'
 import ListTravels from './components/ListTravels'
+import ListBookers from './components/ListBookers'
 import ListNotifiers from './components/ListNotifiers'
 
 export default {
   name: 'App',
   components: {
     AddTravel,
+    AddBooker,
     AddNotifier,
     ListTravels,
+    ListBookers,
     ListNotifiers
   },
   async mounted() {

--- a/frontend/src/components/AddBooker.vue
+++ b/frontend/src/components/AddBooker.vue
@@ -1,0 +1,89 @@
+<template>
+  <form class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+    <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2" for="name">Nom</label>
+      <input
+        class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none"
+        id="name"
+        type="text"
+        placeholder="Name"
+        v-model="name"
+      />
+    </div>
+    <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2" for="type">Type</label>
+      <select
+        class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none"
+        id="type"
+        type="text"
+        v-model="type"
+      >
+        <option disabled value="">Select a type</option>
+        <option v-for="type in types" v-bind:value="type">
+          {{ type }}
+        </option>
+      </select>
+    </div>
+    <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2" for="username">Nom d'utilisateur du service</label>
+      <input
+        class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none"
+        id="username"
+        type="text"
+        placeholder="Username"
+        v-model="username"
+      />
+    </div>
+    <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2" for="password">Mot de passe du service</label>
+      <input
+        class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none"
+        id="password"
+        type="password"
+        placeholder="Password"
+        v-model="password"
+      />
+    </div>
+
+    <div class="text-center">
+      <button
+        class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none"
+        type="button"
+        v-on:click="submitBooker"
+      >Sauvegarder</button>
+    </div>
+  </form>
+</template>
+
+<script>
+export default {
+  name: "AddBooker",
+  data() {
+    return {
+      name: null,
+      username: null,
+      password: null,
+      type: null,
+      types: ['trainline', 'ouisncf']
+    }
+  },
+  methods: {
+    async submitBooker () {
+      const res = await fetch(`${process.env.API_URL}/bookers`, {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          name: this.name,
+          username: this.username,
+          password: this.password,
+          type: this.type
+        })
+      })
+      this.$store.state.bookers.push(await res.json())
+    }
+  }
+}
+</script>

--- a/frontend/src/components/AddTravel.vue
+++ b/frontend/src/components/AddTravel.vue
@@ -59,6 +59,29 @@
       </div>
     </div>
     <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2" for="booker">Booker</label>
+      <select
+        class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none"
+        id="booker"
+        type="text"
+        v-model="booker"
+      >
+        <option disabled value="">Select a booker</option>
+        <option v-for="booker in this.$store.state.bookers" v-bind:value="booker.id">
+          {{ booker.name }} ({{ booker.type }})
+        </option>
+      </select>
+    </div>
+    <div class="mb-4">
+      <label class="block text-gray-700 text-sm font-bold mb-2" for="book">Reservation automatique</label>
+      <input
+        class="form-checkbox leading-tight focus:outline-none"
+        id="book"
+        type="checkbox"
+        v-model="book"
+      />
+    </div>
+    <div class="mb-4">
       <label class="block text-gray-700 text-sm font-bold mb-2" for="notifier">Notifier</label>
       <select
         class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none"
@@ -103,8 +126,10 @@ export default {
     }
   },
   async mounted() {
-    const res = await fetch(`${process.env.API_URL}/notifiers`)
-    this.$store.state.notifiers = await res.json()
+    const notifiers = await fetch(`${process.env.API_URL}/notifiers`)
+    this.$store.state.notifiers = await notifiers.json()
+    const bookers = await fetch(`${process.env.API_URL}/bookers`)
+    this.$store.state.bookers = await bookers.json()
   },
   methods: {
     formatAutocomplete (results) {
@@ -131,7 +156,9 @@ export default {
           date: new Date(this.date.toDateString() + ' UTC'),
           minHour: this.minHour,
           maxHour: this.maxHour,
-          notifier: this.notifier
+          notifier: this.notifier,
+          booker: this.booker,
+          book: this.book
         })
       })
       this.$store.state.travels.push(await res.json())

--- a/frontend/src/components/ListBookers.vue
+++ b/frontend/src/components/ListBookers.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+    <p class="text-4xl mb-8">Bookers</p>
+    <div v-if="this.$store.state.bookers.length === 0" class="flex justify-center items-center">
+      <img src="../assets/benoit.png" class="rounded-full">
+    </div>
+    <div class="rounded overflow-hidden border-r border-b border-l border-t border-gray-400 mb-4" v-for="booker in this.$store.state.bookers">
+      <div class="px-6 py-4">
+        <div class="text-gray-700 text-base">
+          {{ booker.name }} <i>via</i> {{ booker.type }}
+          <button @click="deleteBooker(booker)" class="inline-block bg-red-700 rounded-full px-3 py-1 text-sm text-white mr-2 float-right">Supprimer</button>
+          <div class="clearfix"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "ListBookers",
+  methods: {
+    async deleteBooker (booker) {
+      await fetch(`${process.env.API_URL}/bookers/${booker.id}`, { method: 'DELETE' })
+      const index = this.$store.state.bookers.findIndex(n => n.id === booker.id)
+      this.$store.state.bookers.splice(index, 1)
+    }
+  }
+}
+</script>

--- a/frontend/src/components/ListTravels.vue
+++ b/frontend/src/components/ListTravels.vue
@@ -13,6 +13,9 @@
             <span v-if="travel.minHour"><span v-if="!travel.maxHour">></span>{{ travel.minHour }}h</span><span v-if="travel.minHour && travel.maxHour">-</span><span v-if="travel.maxHour"><span v-if="!travel.minHour"><</span>{{ travel.maxHour }}h</span>
           </div>
         </div>
+        <p v-if="travel.book" class="text-gray-700 text-base">
+          Le train sera réservé avec {{ travel.booker.type }} ({{ travel.booker.name }})
+        </p>
         <p class="text-gray-700 text-base">
           Vous serez notifié via {{ travel.notifier.type }} ({{ travel.notifier.name }})
         </p>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -17,7 +17,8 @@ Vue.config.productionTip = false
 const store = new Vuex.Store({
   state: {
     travels: [],
-    notifiers: []
+    notifiers: [],
+    bookers: []
   }
 })
 


### PR DESCRIPTION
Hi Tousset! 👋

This adds an auto-booking feature that allows the bot to automatically book a train if the train has seats available (currently the first train available between the `minHour` and `maxHour`). This PR introduces some terminologies:
- `booker` is a component that can search and book train (it was a `crawler` before)
- `book` value in `travel` to check if the trip should be automatically booked

It adds the Trainline search and booking system. Note that this one uses the [Trainline business](https://www.trainline.eu/business) API, because this one is much easier to reverse than the public one and is completely free of charge.

I plan to add something like a `CronTravel` to automatically create a `Travel` for a specified date (e.g.: every tuesday at 7 I want to travel from A to B), wdyt?

Waiting for your review