### PR TITLE
chore: add github actions ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: ci
-
+permissions:
+  packages: read|write
 on:
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-
+
+      - name: Push backend
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: backend
+          tags: ghcr.io/${{ github.repository }}-backend:${{ github.sha }}
+
+      - name: Push frontend
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: frontend
+          tags: ghcr.io/${{ github.repository }}-frontend:${{ github.sha }}


### PR DESCRIPTION
This adds a Github CI file to build and push docker images of frontend and backend to Github packages.

It needs a secret name `CR_PAT` which is a token that have the permission `write:packages`.