### PR TITLE
Fix/trainline

### DIFF
--- a/backend/src/book/trainline.ts
+++ b/backend/src/book/trainline.ts
@@ -282,8 +282,13 @@ export default class TrainlineBooker implements BookerInterface {
     const bookableTrips = trips.trips
       .filter(trip => trip.cents === 0 && trip.long_unsellable_reason === undefined) // filter only tgv max trips
       .filter((trip) => {
-        // filter hours (sometimes trainline returns trains that doesn't respect the request)
+        // sometimes trainline returns trains that doesn't respect the request
         const date = new Date(trip.departure_date)
+
+        if (this.travel.date.getDay() !== date.getDay() || this.travel.date.getMonth() !== date.getMonth()) {
+          return false
+        }
+
         if (this.travel.minHour && date.getHours() < this.travel.minHour) {
           return false
         }
@@ -526,7 +531,7 @@ export default class TrainlineBooker implements BookerInterface {
       content += `\n- ${this.travel.from}-${this.travel.to}: ${getHourFromDate(new Date(trip.departure_date))}-${getHourFromDate(new Date(trip.arrival_date))}`
     })
     if (this.travel.book) {
-      content += `\n\n Une reservation va etre tentee pour le premier train.`
+      content += `\n\nUne reservation va etre tentee pour le premier train.`
     }
     return content
   }
@@ -534,7 +539,7 @@ export default class TrainlineBooker implements BookerInterface {
   private formatMessageBooked(trip: SearchTrainResponse['trips'][0], confirm: ConfirmResponse): string {
     let content = `Un billet a ete reserve pour le ${getHumanDate(new Date(trip.departure_date))} et une arrivee le ${getHumanDate(new Date(trip.arrival_date))}:`
     for (const segment of confirm.segments) {
-      content += `\n- train #${segment.train_number || 'inconnu'} (voiture ${segment.car || 'inconnue'} siege ${segment.seat || 'inconnu'})`
+      content += `\n- train ${segment.train_number || 'inconnu'} (voiture ${segment.car || 'inconnue'} siege ${segment.seat || 'inconnu'})`
     }
     return content
   }

--- a/backend/src/utils/date.ts
+++ b/backend/src/utils/date.ts
@@ -1,8 +1,18 @@
 export const getHourFromDate = (date: Date) => {
-  return date.getHours().toString().padStart(2, '0') + 'h' +
-    date.getMinutes().toString().padStart(2, '0')
+  return new Intl.DateTimeFormat([], {
+    timeZone: 'Europe/Paris',
+    hour: 'numeric',
+    minute: 'numeric',
+  }).format(date)
 }
 
 export const getHumanDate = (date: Date) => {
-  return date.toISOString().split('T')[0] + ' a ' + getHourFromDate(date)
+  return new Intl.DateTimeFormat([], {
+    timeZone: 'Europe/Paris',
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  }).format(date)
 }


### PR DESCRIPTION
This fixes some bugs in Trainline booker:
- that can book a train at an incorrect date (mostly when the booker is running with a travel from the past)
- displays hours incorrectly (because of a timezone problem)
- crash because the api is protected by datadome (it now uses Android client ids that doesn't have a datadome protection (akamai header is sent, but apparently not used))