### PR TITLE
filter only the users that are not deleted

### DIFF
--- a/backend/src/book/trainline.ts
+++ b/backend/src/book/trainline.ts
@@ -36,6 +36,7 @@ type LoginResponse = {
   }
   passengers: {
     id: string
+    is_selected: boolean
     first_name: string
     last_name: string
     card_ids: any[]
@@ -519,7 +520,7 @@ export default class TrainlineBooker implements BookerInterface {
     })
     let token: LoginResponse = await res.json()
     this.token = token
-
+    this.token.passengers = token.passengers.filter(p => p.is_selected)
     if (this.token.passengers.length > 1) {
       this.notifier.send(`Il y a ${this.token.passengers.length} passagers sur ce compte Trainline, seulement le premier (${this.token.passengers[0].first_name}) sera utilise pour la reservation.`)
     }


### PR DESCRIPTION
Hello 😄 
Déjà, merci pour ton bot!
Il est 10 fois mieux que celui que j'ai fait il y a deux ans, et qui marchait plus...

Alors j'ai remarqué que pour Trainline, il me prenait des utilisateurs qui sont supprimés. Assez bizarre qu'ils soient encore retourné par l'API d'ailleurs.
Du coup il me selectionnait le premier de la liste qui était un utilisateur supprimé.
En ajoutant ce filtre, le problème était résolu 👍🏻 

Merci en tout cas!

Je vais peut-être revenir avec une autre PR pour ajouter un notifier avec Telegram, je l'utilisais pour mon ancien bot et c'était assez pratique !