### PR TITLE
fix/station-search

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -9,6 +9,9 @@ import BookerController from './src/controllers/booker.controller'
 import CronTravelController from './src/controllers/cronTravel.controller'
 import fetch from 'node-fetch'
 import CronTravelEntity from './src/entities/cronTravel.entity'
+import { TrainlineStation } from './src/book/trainline'
+
+const trainlineStations: TrainlineStation[] = require('./trainline_stations.json')
 
 const db = new Database()
 const app = express()
@@ -32,9 +35,11 @@ db.connect().then(async () => {
     if (req.query.searchTerm.length < 2) {
       return res.send([])
     }
-    // @ts-ignore
-    const result = await fetch(`https://www.oui.sncf/booking/autocomplete-d2d?${req._parsedUrl.query}`)
-    return res.send(await result.json())
+    res.send(trainlineStations.filter((s) => s.name.toLocaleLowerCase().includes(req.query.searchTerm.toLowerCase())).map(searchResult => ({
+      id: searchResult.sncfId,
+      tlId: searchResult.trainlineId,
+      name: searchResult.name,
+    })))
   })
   app.use('/api', router)
 

--- a/backend/src/book/trainline.ts
+++ b/backend/src/book/trainline.ts
@@ -5,7 +5,12 @@ import { NotifierInterface } from '../notify/interface'
 import { getHourFromDate, getHumanDate } from '../utils/date'
 import * as debug from 'debug'
 
-const trainlineStations = require('../../trainline_stations.json')
+const trainlineStations: TrainlineStation[] = require('../../trainline_stations.json')
+export interface TrainlineStation {
+  trainlineId: string
+  sncfId: string
+  name: string
+}
 
 const endpoint = 'https://www.trainline.fr/api/v5_1'
 const headers = {
@@ -243,14 +248,14 @@ export default class TrainlineBooker implements BookerInterface {
     this.logger = debug(`booker:trainline:${this.travel.from}-${this.travel.to}_${this.travel.date}`)
     this.logger(`Init booker`)
 
-    this.departureId = trainlineStations[this.travel.from]
+    this.departureId = trainlineStations.find(s => s.sncfId === this.travel.from).trainlineId
     if (!this.departureId) {
       this.logger(`Cannot get trainline id for station "${this.travel.from}"`)
       return
     }
-    this.arrivalId = trainlineStations[this.travel.to]
+    this.arrivalId = trainlineStations.find(s => s.sncfId === this.travel.to).trainlineId
     if (!this.arrivalId) {
-      this.logger(`Cannot get trainline id for station "${this.travel.from}"`)
+      this.logger(`Cannot get trainline id for station "${this.travel.to}"`)
       return
     }
 

--- a/backend/utils/fetch_trainline_stations.ts
+++ b/backend/utils/fetch_trainline_stations.ts
@@ -1,16 +1,21 @@
 import * as fetch from 'node-fetch'
 const parse = require('csv-parse/lib/sync')
 import { writeFileSync } from 'fs'
+import { TrainlineStation } from '../src/book/trainline'
 
 const main = async () => {
   const res = await fetch('https://raw.githubusercontent.com/trainline-eu/stations/master/stations.csv', {})
-  const stations: Record<string, string> = {}
+  const stations: TrainlineStation[] = []
   const lines = parse(await res.text(), {
     columns: true,
     delimiter: ';'
   })
-  for (const line of lines.filter(line => line.sncf_is_enabled === 't' && line.sncf_id !== '')) {
-    stations[line.sncf_id] = line.id
+  for (const line of lines.filter(line => line.is_suggestable === 't' && line.sncf_is_enabled === 't' && line.sncf_id !== '')) {
+    stations.push({
+      trainlineId: line.id,
+      sncfId: line.sncf_id,
+      name: line.name,
+    })
   }
   writeFileSync('./trainline_stations.json', JSON.stringify(stations))
 }

--- a/frontend/config/prod.env.js
+++ b/frontend/config/prod.env.js
@@ -1,5 +1,5 @@
 'use strict'
 module.exports = {
   NODE_ENV: '"production"',
-  API_URL: '"https://tgvmax.eywek.fr/api"'
+  API_URL: '"/api"'
 }

--- a/frontend/src/components/ModalCron.vue
+++ b/frontend/src/components/ModalCron.vue
@@ -155,7 +155,7 @@ export default {
       booker: null,
       book: true,
       maxTravels: null,
-      autocompleteEndpoint: `${process.env.API_URL}/stations/autocomplete?uc=fr-FR&searchField=origin&searchTerm=`
+      autocompleteEndpoint: `${process.env.API_URL}/stations/autocomplete?searchTerm=`
     }
   },
   computed: {
@@ -164,9 +164,7 @@ export default {
   },
   methods: {
     formatAutocomplete (results) {
-      return results.filter((result) => {
-        return result.category === 'station' && (result.type === 'G' || result.type === 'L')
-      }).map(r => ({ label: r.label, id: r.rrCode || r.id.replace('RESARAIL_STA_', '') }))
+      return results.map(r => ({ label: r.name, id: r.id }))
     },
     autocompleteSelected (key) {
       return (value) => {

--- a/frontend/src/components/ModalTravel.vue
+++ b/frontend/src/components/ModalTravel.vue
@@ -138,7 +138,7 @@ export default {
       notifier: null,
       booker: null,
       book: true,
-      autocompleteEndpoint: `${process.env.API_URL}/stations/autocomplete?uc=fr-FR&searchField=origin&searchTerm=`
+      autocompleteEndpoint: `${process.env.API_URL}/stations/autocomplete?searchTerm=`
     }
   },
   computed: {
@@ -147,9 +147,7 @@ export default {
   },
   methods: {
     formatAutocomplete (results) {
-      return results.filter((result) => {
-        return result.category === 'station' && (result.type === 'G' || result.type === 'L')
-      }).map(r => ({ label: r.label, id: r.rrCode || r.id.replace('RESARAIL_STA_', '') }))
+      return results.map(r => ({ label: r.name, id: r.id }))
     },
     autocompleteSelected (key) {
       return (value) => {


### PR DESCRIPTION
This fixes the search that was broken by the migration of _oui sncf_ to _sncf connect_. The bot now uses the CSV from _trainline_ and makes a text search on it. The generator produces a 282Kb JSON file.

Yes, the text search is pretty bad (I'm too lazy to make something okay-ish), actually it takes less than 2ms to search a station.

I updated the API_ENDPOINT too because it's not usable on any other system as it is.